### PR TITLE
lit-element → lit 2.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,6 @@
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "rules": {
     "prettier/prettier": "error",
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": 0
   }
 }

--- a/_templates/element/new/element.stories.ts.t
+++ b/_templates/element/new/element.stories.ts.t
@@ -1,7 +1,7 @@
 ---
 to: src/<%= name %>-element.stories.ts
 ---
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './<%= name %>-element';
 
 export default {

--- a/_templates/element/new/element.ts.t
+++ b/_templates/element/new/element.ts.t
@@ -1,7 +1,8 @@
 ---
 to: src/<%= name %>-element.ts
 ---
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property} from 'lit/decorators.js';
 
 @customElement('wokwi-<%= name %>')
 export class <%= h.className(name) %>Element extends LitElement {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3701,6 +3701,11 @@
         }
       }
     },
+    "@lit/reactive-element": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0.tgz",
+      "integrity": "sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA=="
+    },
     "@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",
@@ -12256,6 +12261,11 @@
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
     "@types/uglify-js": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
@@ -12342,15 +12352,16 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.32.0.tgz",
+      "integrity": "sha512-+OWTuWRSbWI1KDK8iEyG/6uK2rTm3kpS38wuVifGUTDB6kjEuNrzBI1MUtxnkneuWG/23QehABe2zHHrj+4yuA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.1",
-        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/experimental-utils": "4.32.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
@@ -12365,6 +12376,12 @@
             "ms": "2.1.2"
           }
         },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -12377,15 +12394,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-      "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.32.0.tgz",
+      "integrity": "sha512-WLoXcc+cQufxRYjTWr4kFt0DyEv6hDgSaFqYhIzQZ05cF+kXfqXdUh+//kgquPJVUBbL3oQGKQxwPbLxHRqm6A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.32.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/typescript-estree": "4.32.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -12399,14 +12416,14 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.32.0.tgz",
+      "integrity": "sha512-lhtYqQ2iEPV5JqV7K+uOVlPePjClj4dOw7K4/Z1F2yvjIUvyr13yJnDzkK6uon4BjHYuHy3EG0c2Z9jEhFk56w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.32.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/typescript-estree": "4.32.0",
         "debug": "^4.3.1"
       },
       "dependencies": {
@@ -12422,29 +12439,41 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz",
+      "integrity": "sha512-DK+fMSHdM216C0OM/KR1lHXjP1CNtVIhJ54kQxfOE6x8UGFAjha8cXgDMBEIYS2XCYjjCtvTkjQYwL3uvGOo0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/visitor-keys": "4.32.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.32.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz",
+          "integrity": "sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.32.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz",
+      "integrity": "sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.32.0.tgz",
+      "integrity": "sha512-tRYCgJ3g1UjMw1cGG8Yn1KzOzNlQ6u1h9AmEtPhb5V5a1TmiHWcRyF/Ic+91M4f43QeChyYlVTcf3DvDTZR9vw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/visitor-keys": "4.32.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -12452,6 +12481,16 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.32.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz",
+          "integrity": "sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.32.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -12490,16 +12529,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -19130,18 +19159,32 @@
         }
       }
     },
-    "lit-element": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
-      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
+    "lit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0.tgz",
+      "integrity": "sha512-pqi5O/wVzQ9Bn4ERRoYQlt1EAUWyY5Wv888vzpoArbtChc+zfUv1XohRqSdtQZYCogl0eHKd+MQwymg2XJfECg==",
       "requires": {
-        "lit-html": "^1.1.1"
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
+      }
+    },
+    "lit-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0.tgz",
+      "integrity": "sha512-oPqRhhBBhs+AlI62QLwtWQNU/bNK/h2L1jI3IDroqZubo6XVAkyNy2dW3CRfjij8mrNlY7wULOfyyKKOnfEePA==",
+      "requires": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit-html": "^2.0.0"
       }
     },
     "lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0.tgz",
+      "integrity": "sha512-tJsCapCmc0vtLj6harqd6HfCxnlt/RSkgowtz4SC9dFE3nSL38Tb33I5HMDiyJsRjQZRTgpVsahrnDrR9wg27w==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -19721,16 +19764,6 @@
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
       }
     },
     "mississippi": {
@@ -23548,14 +23581,12 @@
     },
     "tar": {
       "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "resolved": "",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "husky": "^6.0.0",
     "hygen": "^6.1.0",
     "lint-staged": "^10.2.11",
-    "lit-html": "^1.4.0",
     "prettier": "^2.3.2",
     "react-is": "^16.13.1",
     "rimraf": "^3.0.2",
@@ -42,7 +41,7 @@
     "web-component-analyzer": "^1.1.6"
   },
   "dependencies": {
-    "lit-element": "^2.3.1"
+    "lit": "^2.0.0"
   },
   "scripts": {
     "build": "rimraf dist && tsc --sourceMap false && tsc -m esnext --outDir dist/esm --sourceMap false && rollup -c rollup.config.js && terser -c -m -o dist/wokwi-elements.bundle.min.js dist/wokwi-elements.bundle.js",

--- a/src/7segment-element.stories.ts
+++ b/src/7segment-element.stories.ts
@@ -1,6 +1,6 @@
 import { withKnobs, select } from '@storybook/addon-knobs';
 import { storiesOf, forceReRender } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './7segment-element';
 
 class SpinnerAnimation {

--- a/src/7segment-element.ts
+++ b/src/7segment-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property, svg } from 'lit-element';
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 import { mmToPix } from './utils/units';
 

--- a/src/analog-joystick-element.stories.ts
+++ b/src/analog-joystick-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './analog-joystick-element';
 
 export default {

--- a/src/analog-joystick-element.ts
+++ b/src/analog-joystick-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property, query } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import { analog, ElementPin, GND, VCC } from './pin';
 import { SPACE_KEYS } from './utils/keys';
 

--- a/src/arduino-mega-element.stories.ts
+++ b/src/arduino-mega-element.stories.ts
@@ -1,6 +1,6 @@
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './arduino-mega-element';
 
 storiesOf('Arduino Mega', module)

--- a/src/arduino-mega-element.ts
+++ b/src/arduino-mega-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property, svg } from 'lit-element';
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { pinsFemalePattern } from './patterns/pins-female';
 import { analog, ElementPin, i2c, spi, usart } from './pin';
 

--- a/src/arduino-nano-element.stories.ts
+++ b/src/arduino-nano-element.stories.ts
@@ -1,6 +1,6 @@
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { action } from '@storybook/addon-actions';
 import './arduino-nano-element';
 

--- a/src/arduino-nano-element.ts
+++ b/src/arduino-nano-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg, query, css } from 'lit-element';
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import { analog, ElementPin, i2c, spi, usart } from './pin';
 import { SPACE_KEYS } from './utils/keys';
 

--- a/src/arduino-uno-element.stories.ts
+++ b/src/arduino-uno-element.stories.ts
@@ -1,6 +1,6 @@
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './arduino-uno-element';
 
 storiesOf('Arduino Uno', module)

--- a/src/arduino-uno-element.ts
+++ b/src/arduino-uno-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property, svg } from 'lit-element';
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { pinsFemalePattern } from './patterns/pins-female';
 import { analog, ElementPin, i2c, spi, usart } from './pin';
 

--- a/src/big-sound-sensor-element.stories.ts
+++ b/src/big-sound-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './big-sound-sensor-element';
 
 export default {

--- a/src/big-sound-sensor-element.ts
+++ b/src/big-sound-sensor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { GND, VCC } from './pin';
 

--- a/src/buzzer-element.stories.ts
+++ b/src/buzzer-element.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/web-components';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './buzzer-element';
 
 storiesOf('Buzzer', module)

--- a/src/buzzer-element.ts
+++ b/src/buzzer-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 /**

--- a/src/dht22-element.stories.ts
+++ b/src/dht22-element.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './dht22-element';
 
 storiesOf('DHT22', module)

--- a/src/dht22-element.ts
+++ b/src/dht22-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 @customElement('wokwi-dht22')

--- a/src/ds1307-element.stories.ts
+++ b/src/ds1307-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './ds1307-element';
 
 export default {

--- a/src/ds1307-element.ts
+++ b/src/ds1307-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin, GND, i2c, VCC } from './pin';
 
 @customElement('wokwi-ds1307')

--- a/src/esp32-devkit-v1-element.stories.ts
+++ b/src/esp32-devkit-v1-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './esp32-devkit-v1-element';
 
 export default {

--- a/src/esp32-devkit-v1-element.ts
+++ b/src/esp32-devkit-v1-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { i2c, spi, usart } from './pin';
 

--- a/src/flame-sensor-element.stories.ts
+++ b/src/flame-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './flame-sensor-element';
 
 export default {

--- a/src/flame-sensor-element.ts
+++ b/src/flame-sensor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { GND, VCC } from './pin';
 

--- a/src/franzininho-element.stories.ts
+++ b/src/franzininho-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { action } from '@storybook/addon-actions';
 import './franzininho-element';
 

--- a/src/franzininho-element.ts
+++ b/src/franzininho-element.ts
@@ -1,4 +1,5 @@
-import { customElement, LitElement, property, html, svg, query, css } from 'lit-element';
+import { html, LitElement, svg, css } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import { pinsFemalePattern } from './patterns/pins-female';
 import { analog, ElementPin, i2c, spi } from './pin';
 import { SPACE_KEYS } from './utils/keys';

--- a/src/gas-sensor-element.stories.ts
+++ b/src/gas-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './gas-sensor-element';
 
 export default {

--- a/src/gas-sensor-element.ts
+++ b/src/gas-sensor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { GND, VCC } from './pin';
 

--- a/src/hc-sr04-element.stories.ts
+++ b/src/hc-sr04-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './hc-sr04-element';
 
 export default {

--- a/src/hc-sr04-element.ts
+++ b/src/hc-sr04-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 @customElement('wokwi-hc-sr04')

--- a/src/heart-beat-sensor-element.stories.ts
+++ b/src/heart-beat-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './heart-beat-sensor-element';
 
 export default {

--- a/src/heart-beat-sensor-element.ts
+++ b/src/heart-beat-sensor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin, GND, VCC } from './pin';
 
 @customElement('wokwi-heart-beat-sensor')

--- a/src/ili9341-element.stories.ts
+++ b/src/ili9341-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { drawWokwiW } from './utils/logo';
 import './ili9341-element';
 

--- a/src/ili9341-element.ts
+++ b/src/ili9341-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin, spi } from './pin';
 
 @customElement('wokwi-ili9341')

--- a/src/ir-receiver-element.stories.ts
+++ b/src/ir-receiver-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './ir-receiver-element';
 
 export default {

--- a/src/ir-receiver-element.ts
+++ b/src/ir-receiver-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin, GND, VCC } from './pin';
 
 @customElement('wokwi-ir-receiver')

--- a/src/ir-remote-element.stories.ts
+++ b/src/ir-remote-element.stories.ts
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './ir-remote-element';
 
 export default {

--- a/src/ir-remote-element.ts
+++ b/src/ir-remote-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { SPACE_KEYS } from './utils/keys';
 
 const irKeyCodes: { [key: string]: number } = {

--- a/src/ky-040-element.stories.ts
+++ b/src/ky-040-element.stories.ts
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './ky-040-element';
 
 export default {

--- a/src/ky-040-element.ts
+++ b/src/ky-040-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { GND, VCC } from './pin';
 

--- a/src/lcd1602-element.stories.ts
+++ b/src/lcd1602-element.stories.ts
@@ -1,6 +1,6 @@
 import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { fontA02 } from './lcd1602-font-a02';
 import './lcd1602-element';
 

--- a/src/lcd1602-element.ts
+++ b/src/lcd1602-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, css, svg } from 'lit-element';
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { fontA00 } from './lcd1602-font-a00';
 import { ElementPin, i2c } from './pin';
 import { mmToPix } from './utils/units';

--- a/src/lcd2004-element.stories.ts
+++ b/src/lcd2004-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { fontA02 } from './lcd1602-font-a02';
 import './lcd2004-element';
 

--- a/src/lcd2004-element.ts
+++ b/src/lcd2004-element.ts
@@ -1,4 +1,4 @@
-import { customElement } from 'lit-element';
+import { customElement } from 'lit/decorators.js';
 import { LCD1602Element } from './lcd1602-element';
 
 @customElement('wokwi-lcd2004')

--- a/src/led-bar-graph-element.stories.ts
+++ b/src/led-bar-graph-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './led-bar-graph-element';
 
 export default {

--- a/src/led-bar-graph-element.ts
+++ b/src/led-bar-graph-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 import { mmToPix } from './utils/units';
 

--- a/src/led-element.stories.ts
+++ b/src/led-element.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/web-components';
 import { withKnobs, boolean, text, number } from '@storybook/addon-knobs';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './led-element';
 
 const brightnessOptions = {

--- a/src/led-element.ts
+++ b/src/led-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 const lightColors: { [key: string]: string } = {

--- a/src/led-ring-element.stories.ts
+++ b/src/led-ring-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './led-ring-element';
 
 export default {

--- a/src/led-ring-element.ts
+++ b/src/led-ring-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 import { RGB } from './types/rgb';
 import { mmToPix } from './utils/units';

--- a/src/membrane-keypad-element.stories.ts
+++ b/src/membrane-keypad-element.stories.ts
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './membrane-keypad-element';
 
 storiesOf('Membrane Keypad', module)

--- a/src/membrane-keypad-element.ts
+++ b/src/membrane-keypad-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { pinsFemalePattern } from './patterns/pins-female';
 import { ElementPin } from './pin';
 import { SPACE_KEYS } from './utils/keys';

--- a/src/microsd-card-element.stories.ts
+++ b/src/microsd-card-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './microsd-card-element';
 
 export default {

--- a/src/microsd-card-element.ts
+++ b/src/microsd-card-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { spi } from './pin';
 

--- a/src/mpu6050-element.stories.ts
+++ b/src/mpu6050-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './mpu6050-element';
 
 export default {

--- a/src/mpu6050-element.ts
+++ b/src/mpu6050-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { GND, i2c, VCC } from './pin';
 

--- a/src/nano-rp2040-connect-element.stories.ts
+++ b/src/nano-rp2040-connect-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './nano-rp2040-connect-element';
 
 export default {

--- a/src/nano-rp2040-connect-element.ts
+++ b/src/nano-rp2040-connect-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { analog, spi, usart } from './pin';
 

--- a/src/neopixel-element.stories.ts
+++ b/src/neopixel-element.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/web-components';
 import { withKnobs, number } from '@storybook/addon-knobs';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './neopixel-element';
 
 storiesOf('Neopixel', module)

--- a/src/neopixel-element.ts
+++ b/src/neopixel-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin, GND, VCC } from './pin';
 
 @customElement('wokwi-neopixel')

--- a/src/neopixel-matrix-element.stories.ts
+++ b/src/neopixel-matrix-element.stories.ts
@@ -1,6 +1,6 @@
 import { withKnobs, number, boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './neopixel-matrix-element';
 
 storiesOf('NeoPixel Matrix', module)

--- a/src/neopixel-matrix-element.ts
+++ b/src/neopixel-matrix-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property, svg } from 'lit-element';
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin, GND, VCC } from './pin';
 import { RGB } from './types/rgb';
 import { mmToPix } from './utils/units';

--- a/src/ntc-temperature-sensor-element.stories.ts
+++ b/src/ntc-temperature-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './ntc-temperature-sensor-element';
 
 export default {

--- a/src/ntc-temperature-sensor-element.ts
+++ b/src/ntc-temperature-sensor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { analog, ElementPin, GND, VCC } from './pin';
 
 @customElement('wokwi-ntc-temperature-sensor')

--- a/src/patterns/pins-female.ts
+++ b/src/patterns/pins-female.ts
@@ -1,4 +1,4 @@
-import { svg } from 'lit-element';
+import { svg } from 'lit';
 
 export const pinsFemalePattern = svg`
   <pattern id="pins-female" width="2.54" height="2.54" patternUnits="userSpaceOnUse">

--- a/src/photoresistor-sensor-element.stories.ts
+++ b/src/photoresistor-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './photoresistor-sensor-element';
 
 export default {

--- a/src/photoresistor-sensor-element.ts
+++ b/src/photoresistor-sensor-element.ts
@@ -1,6 +1,7 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
-import { VCC, GND, analog } from './pin';
+import { analog, GND, VCC } from './pin';
 
 @customElement('wokwi-photoresistor-sensor')
 export class PhotoresistorSensorElement extends LitElement {

--- a/src/pir-motion-sensor-element.stories.ts
+++ b/src/pir-motion-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './pir-motion-sensor-element';
 
 export default {

--- a/src/pir-motion-sensor-element.ts
+++ b/src/pir-motion-sensor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin, GND, VCC } from './pin';
 
 @customElement('wokwi-pir-motion-sensor')

--- a/src/potentiometer-element.stories.ts
+++ b/src/potentiometer-element.stories.ts
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './potentiometer-element';
 
 storiesOf('Potentiometer', module)

--- a/src/potentiometer-element.ts
+++ b/src/potentiometer-element.ts
@@ -1,5 +1,6 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
-import { styleMap } from 'lit-html/directives/style-map';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
 import { analog, ElementPin } from './pin';
 import { clamp } from './utils/clamp';
 

--- a/src/pushbutton-element.stories.ts
+++ b/src/pushbutton-element.stories.ts
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './pushbutton-element';
 
 export default {

--- a/src/pushbutton-element.ts
+++ b/src/pushbutton-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 import { SPACE_KEYS } from './utils/keys';
 

--- a/src/resistor-element.stories.ts
+++ b/src/resistor-element.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { withKnobs, number } from '@storybook/addon-knobs';
 
 import './resistor-element';

--- a/src/resistor-element.ts
+++ b/src/resistor-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 const bandColors: { [key: number]: string } = {

--- a/src/rgb-led-element.stories.ts
+++ b/src/rgb-led-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './rgb-led-element';
 
 export default {

--- a/src/rgb-led-element.ts
+++ b/src/rgb-led-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
 
 @customElement('wokwi-rgb-led')

--- a/src/rotary-dailer-element.stories.ts
+++ b/src/rotary-dailer-element.stories.ts
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './rotary-dialer-element';
 
 storiesOf('Rotary Dialer', module)

--- a/src/rotary-dialer-element.ts
+++ b/src/rotary-dialer-element.ts
@@ -1,6 +1,7 @@
-import { css, customElement, html, LitElement } from 'lit-element';
-import { styleMap } from 'lit-html/directives/style-map';
-import { classMap } from 'lit-html/directives/class-map';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 type InitialValue = '';
 type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;

--- a/src/servo-element.stories.ts
+++ b/src/servo-element.stories.ts
@@ -1,6 +1,6 @@
 import { number, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf, forceReRender } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './servo-element';
 
 class SweepAnimation {

--- a/src/servo-element.ts
+++ b/src/servo-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 @customElement('wokwi-servo')

--- a/src/slide-potentiometer-element.stories.ts
+++ b/src/slide-potentiometer-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { action } from '@storybook/addon-actions';
 import './slide-potentiometer-element';
 

--- a/src/slide-potentiometer-element.ts
+++ b/src/slide-potentiometer-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
+import { html, LitElement, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { analog, ElementPin } from './pin';
 import { clamp } from './utils/clamp';
 import { mmToPix } from './utils/units';

--- a/src/slide-switch-element.stories.ts
+++ b/src/slide-switch-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './slide-switch-element';
 import { action } from '@storybook/addon-actions';
 

--- a/src/slide-switch-element.ts
+++ b/src/slide-switch-element.ts
@@ -1,4 +1,5 @@
-import { css, customElement, html, LitElement, property } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from './pin';
 
 @customElement('wokwi-slide-switch')

--- a/src/small-sound-sensor-element.stories.ts
+++ b/src/small-sound-sensor-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './small-sound-sensor-element';
 
 export default {

--- a/src/small-sound-sensor-element.ts
+++ b/src/small-sound-sensor-element.ts
@@ -1,6 +1,7 @@
-import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin } from '.';
-import { VCC, GND } from './pin';
+import { GND, VCC } from './pin';
 
 @customElement('wokwi-small-sound-sensor')
 export class SmallSoundSensorElement extends LitElement {

--- a/src/ssd1306-element.stories.ts
+++ b/src/ssd1306-element.stories.ts
@@ -1,6 +1,6 @@
 import { withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/web-components';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './ssd1306-element';
 
 const logoBitmap = new Uint8Array([

--- a/src/ssd1306-element.ts
+++ b/src/ssd1306-element.ts
@@ -1,5 +1,6 @@
 // Reference: https://cdn-learn.adafruit.com/assets/assets/000/036/494/original/lcds___displays_fabprint.png?1476374574
-import { customElement, html, LitElement, property, SVGTemplateResult, css } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { ElementPin, i2c } from './pin';
 
 type CanvasContext = CanvasRenderingContext2D | null | undefined;
@@ -79,7 +80,7 @@ export class SSD1306Element extends LitElement {
     }
   }
 
-  render(): SVGTemplateResult {
+  render() {
     const { width, height, screenWidth, screenHeight } = this;
     return html` <div class="container">
       <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">

--- a/src/tilt-switch-element.stories.ts
+++ b/src/tilt-switch-element.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './tilt-switch-element';
 
 export default {

--- a/src/tilt-switch-element.ts
+++ b/src/tilt-switch-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { ElementPin } from '.';
 import { GND, VCC } from './pin';
 

--- a/src/utils/show-pins-element.ts
+++ b/src/utils/show-pins-element.ts
@@ -1,4 +1,5 @@
-import { customElement, html, LitElement, property, query, svg } from 'lit-element';
+import { html, LitElement, svg } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import { ElementPin } from '../pin';
 
 export interface ElementWithPinInfo extends Element {


### PR DESCRIPTION
Migrate from lit-element to the new [lit](https://lit.dev) package:

https://lit.dev/docs/releases/upgrade/

Also upgrade typescript-eslint to 4.24.0, as the current version chokes with an error:

```
src/neopixel-matrix-element.ts
  0:0  error  Parsing error: Cannot read property 'map' of undefined
```

This still WiP - waiting for storybook to support lit 2.0 properly.