### PR TITLE
Add 3 digits variant to 7segment-element

### DIFF
--- a/src/7segment-element.ts
+++ b/src/7segment-element.ts
@@ -69,6 +69,22 @@ export class SevenSegmentElement extends LitElement {
           { name: 'CLN', ...pinXY(8), signals: [], description: 'Colon' },
         ];
 
+        case 3:
+          // Pinout based on SP420281N model
+          return [
+            { name: 'A', ...pinXY(11), signals: [], description: 'Segment A' },
+            { name: 'B', ...pinXY(7), signals: [], description: 'Segment B' },
+            { name: 'C', ...pinXY(4), signals: [], description: 'Segment C' },
+            { name: 'D', ...pinXY(2), signals: [], description: 'Segment D' },
+            { name: 'E', ...pinXY(1), signals: [], description: 'Segment E' },
+            { name: 'F', ...pinXY(10), signals: [], description: 'Segment F' },
+            { name: 'G', ...pinXY(5), signals: [], description: 'Segment G' },
+            { name: 'DP', ...pinXY(3), signals: [], description: 'Decimal Point' },
+            { name: 'DIG1', ...pinXY(12), signals: [], description: 'Digit 1 Common' },
+            { name: 'DIG2', ...pinXY(9), signals: [], description: 'Digit 2 Common' },
+            { name: 'DIG3', ...pinXY(8), signals: [], description: 'Digit 3 Common' },
+          ];
+
       case 2:
         // Pinout based on CL5621C model
         return [


### PR DESCRIPTION
As discussed in https://github.com/wokwi/wokwi-features/issues/383, this adds a 3 digits variant to the _7segment_ part.

I was not able to identify a model that was more popular to others, but most Chinese manufacturers seems to use the same pinout ([see LCSC datasheets](https://lcsc.com/products/Led-Segment-Display_532.html)).

Finally, pin 6 is not connected. I am not sure what is the convention for Wokwi in this case.